### PR TITLE
Password blog post

### DIFF
--- a/2020-05-16-password-2.0.md
+++ b/2020-05-16-password-2.0.md
@@ -28,7 +28,7 @@ dealing with passwords and password hashing in any type of application.
 There are four main advantages of using `password`:
 
 -   Canonical
-    [`Password`](https://hackage.haskell.org/package/password-2.0.1.1/docs/Data-Password.html#t:PasswordHash)
+    [`Password`](https://hackage.haskell.org/package/password-2.0.1.1/docs/Data-Password.html#t:Password)
     and
     [`PasswordHash`](https://hackage.haskell.org/package/password-2.0.1.1/docs/Data-Password.html#t:PasswordHash)
     types that can be shared throughout your code. These are meant to be simple
@@ -119,7 +119,7 @@ function.  This produces a
 [`PasswordHash`](https://hackage.haskell.org/package/password-2.0.1.1/docs/Data-Password-Bcrypt.html#t:PasswordHash):
 
 ```haskell
-> let hash = hashPassword pass
+> hash <- hashPassword pass
 > hash :: PasswordHash Bcrypt
 PasswordHash {unPasswordHash = "$2b$10$IbnlktUyGjeunSlE4bQtfu89LY6veyDW0CGIoR5Kj8qrQa916txMS"}
 ```
@@ -161,7 +161,9 @@ anyone interested!
 
 -   Add more password hashing algorithms.
 
--   Split the `password-instances` package into separate packages.
+-   Split the
+    [`password-instances`](https://hackage.haskell.org/package/password-instances-2.0.0.1)
+    package into separate packages.
 
     Currently, `password-instances` has instances for `Password` and
     `PasswordHash` for type classes from `aeson` and `persistent`.
@@ -182,7 +184,7 @@ anyone interested!
 
     If you use `password`, please consider contributing missing instances!
 
--   Add functionality for validating passwords complexity requirements.
+-   Add functionality for validating password complexity requirements.
 
     `password` currently doesn't provide any functionality for validating the
     complexity of passwords.  It would be nice if it provided an API for
@@ -221,7 +223,8 @@ There were a few other people who contributed as well:
     attack when checking password hashes.
 
 -   [Tristan de Cacqueray](https://github.com/TristanCacqueray)
-    [fixed up](https://github.com/cdepillabout/password/pull/19) some of our Haddocks.
+    helped to [fixed up](https://github.com/cdepillabout/password/pull/19) some
+    of our Haddocks.
 
 Thanks to everyone, and I hope we get more contributions in the future!
 

--- a/2020-05-16-password-2.0.md
+++ b/2020-05-16-password-2.0.md
@@ -47,27 +47,198 @@ There are four main advantages of using `password`:
     [FromHttpApiData](https://hackage.haskell.org/package/password-instances-2.0.0.1/docs/Data-Password-Instances.html#v:-36-fFromHttpApiDataPassword)
     (from [http-api-data](https://hackage.haskell.org/package/http-api-data)),
     and
-    [PersistField](https://hackage.haskell.org/package/password-instances-2.0.0.1/docs/Data-Password-Instances.html#v:-36-fFromHttpApiDataPassword)
+    [PersistField](https://hackage.haskell.org/package/password-instances-2.0.0.1/docs/Data-Password-Instances.html#v:-36-fPersistFieldPasswordHash)
     (from [persistent](https://hackage.haskell.org/package/persistent)).  These
     instances are frequently used when doing actual web development.
 
--   Great documentation.  Anything that is confusing in the Haddocks is
-    considered a "high-priority" bug.
+-   Great documentation.  Anything confusing in the Haddocks is considered a
+    "high-priority" bug.
 
-## What was changed in `password-2.0`?
+## What has changed in `password-2.0`?
 
+`password-2.0` is a complete rewrite of the `password` library by [Felix
+Paulusma](https://github.com/Vlix)[^1].  The architecture of the library has
+been completely redone to allow the library to support multiple hashing
+algorithms.
+
+The following algorithms are now supported:
+
+-   [Argon2](https://hackage.haskell.org/package/password-2.0.1.1/docs/Data-Password-Argon2.html)
+-   [Bcrypt](https://hackage.haskell.org/package/password-2.0.1.1/docs/Data-Password-Bcrypt.html)
+-   [PBKDF2](https://hackage.haskell.org/package/password-2.0.1.1/docs/Data-Password-PBKDF2.html)
+-   [Scrypt](https://hackage.haskell.org/package/password-2.0.1.1/docs/Data-Password-Scrypt.html)
+    (this was the only algorithm supported in the original `password` library)
+
+`password-2.0` also adds a bunch of much-needed documentation, as well as many
+tests.
+
+## How to use `password`?
+
+This section will present a short tutorial for using `password`.  The following
+commands are run in a GHCi session.  You can follow along if you start GHCi
+with a command like `stack --resolver nightly-2020-05-17 ghci --package
+password-2.0.1.1`.
+
+We enable a couple extensions to make the following code a little easier:
+
+```haskell
+> :set -XOverloadedStrings
+```
+
+The first step in using `password` is to pick which hashing algorithm you want to use.
+If you don't know which to pick, we recommend
+[Bcrypt](https://hackage.haskell.org/package/password-2.0.1.1/docs/Data-Password-Bcrypt.html).
+The tradeoffs of the different algorithms are discussed in more detail
+[in the Haddocks](https://hackage.haskell.org/package/password-2.0.1.1/docs/Data-Password.html).
+
+Once, you've picked the hashing algorithm, you can import its module.  We use
+[`Data.Password.Bcrypt`](https://hackage.haskell.org/package/password-2.0.1.1/docs/Data-Password-Bcrypt.html)
+as an example:
+
+```haskell
+> import Data.Password.Bcrypt
+```
+
+Next, we need a
+[`Password`](https://hackage.haskell.org/package/password-2.0.1.1/docs/Data-Password-Bcrypt.html#t:Password)
+to work with.  Let's create one with
+[`mkPassword`](https://hackage.haskell.org/package/password-2.0.1.1/docs/Data-Password-Bcrypt.html#v:mkPassword)[^2]:
+
+```haskell
+> let pass = mkPassword "foobar"
+> pass :: Password
+**PASSWORD**
+```
+
+Note that the `Show` instance for `Password` doesn't actually show the
+password.  This is a security measure.  You don't have to worry about passwords
+leaking into your web application logs.
+
+Now that you have a password, we can hash it with the
+[`hashPassword`](https://hackage.haskell.org/package/password-2.0.1.1/docs/Data-Password-Bcrypt.html#v:hashPassword)
+function.  This produces a
+[`PasswordHash`](https://hackage.haskell.org/package/password-2.0.1.1/docs/Data-Password-Bcrypt.html#t:PasswordHash):
+
+```haskell
+> let hash = hashPassword pass
+> hash :: PasswordHash Bcrypt
+PasswordHash {unPasswordHash = "$2b$10$IbnlktUyGjeunSlE4bQtfu89LY6veyDW0CGIoR5Kj8qrQa916txMS"}
+```
+
+This `PasswordHash` can be stored in a database[^3].
+
+The
+[`checkPassword`](https://hackage.haskell.org/package/password-2.0.1.1/docs/Data-Password-Bcrypt.html#v:checkPassword)
+function can be used to check a `Password` against a `PasswordHash`:
+
+```haskell
+> let result = checkPassword pass hash
+> result :: PasswordCheck
+PasswordCheckSuccess
+```
 
 ## Future Work
 
--   security audit
--   splitting off the Data.Password module into a separate package called `password-types`.
--   adding more password hashing algorithms
--   splitting the `password-instances` package into separate packages like `password-instances-aeson`.
--   adding more helpful `password-instances` instances.
--   functionality for validating passwords
+There are a few issues in the `password` library that we'd like help with from
+anyone interested!
+
+-   Split off the
+    [`Data.Password`](https://hackage.haskell.org/package/password-2.0.1.1/docs/Data-Password.html)
+    module into a separate package called `password-types`.
+
+    All of the hashing algorithms provided in `password` come from
+    [`cryptonite`](https://hackage.haskell.org/package/cryptonite).
+
+    However, we would ideally like people to be able to use the `Password` and
+    `PasswordHash` data types as canonical data types in different libraries on
+    Hackage.  We don't want all these packages to have to pull in a transitive
+    dependency on `cryptonite`.
+
+    Ideally, we would have a `password-types` package that just exports
+    everything from the current `Data.Password` module, which doesn't require a
+    dependency on `cryptonite`.
+
+    https://github.com/cdepillabout/password/issues/20
+
+-   Add more password hashing algorithms.
+
+-   Split the `password-instances` package into separate packages.
+
+    Currently, `password-instances` has instances for `Password` and
+    `PasswordHash` for type classes from `aeson` and `persistent`.  However,
+    ideally there would be a more fine-grained way to pick only the instances
+    you want.
+
+    For instance, if you're not using `persistent` to access a database, you
+    shouldn't have to transitively depend on `persistent` just to get instances
+    from `aeson`.
+
+    https://github.com/cdepillabout/password/issues/1
+
+-   Add more helpful instances to `password-instances`.
+
+    `password-instances` has helpful instances from a few widely used libraries,
+    but it is missing many more.
+
+    If you use `password`, please consider contributing missing instances!
+
+-   Add functionality for validating passwords complexity requirements.
+
+    `password` currently doesn't provide any functionality for validating the
+    complexity of passwords.  It would be nice if it provided an API for
+    checking whether passwords are at least a given length, have a certain
+    number of uppercase, lowercase, and special characters, etc.
+
+    This might be of interest to anyone who likes designing easy-to-use APIs
+    for complicated use-cases.
+
+    https://github.com/cdepillabout/password/issues/9
+
+-   Perform a security audit.
+
+    We'd love to get an in-depth review from any security-minded Haskellers.
+    `password` mostly just wraps around functionality provided by `cryptonite`,
+    but it would still be great to get a review for the code we do have.
+
+    If you find any big issues, feel free to
+    [email me directly](https://functor.tokyo/about) if you don't feel
+    comfortable creating a public issue on GitHub.
+
+Please feel free to send PRs or create issues for any of the above enhancements.
 
 ## Conclusion and Thanks
 
-- felix
-- maralorn and scrypt maintainer https://github.com/cdepillabout/password/issues/15
+I need to give a big thanks to [Felix Paulusma](https://github.com/Vlix) for
+`password-2.0`.  He is solely responsible for almost all the
+[work](https://github.com/cdepillabout/password/pull/8) that went
+into this 2.0 release.  Felix is now a full maintainer of `password`.
+
+There were a few other people who contributed as well:
+
+-   [Malte Brandy](https://github.com/maralorn) and
+    [Falko Peters](https://github.com/informatikr) helped with an
+    [issue](https://github.com/cdepillabout/password/issues/15) about a timing
+    attack when checking password hashes.
+
+-   [Tristan de Cacqueray](https://github.com/TristanCacqueray)
+    [fixed up](https://github.com/cdepillabout/password/pull/19) some of our Haddocks.
+
+Thanks to everyone, and I hope we get some more contributions in the future!
+
+## Footnotes
+
+[^1]: The bulk of this work happened in
+    [this PR](https://github.com/cdepillabout/password/pull/8).
+
+[^2]: In reality, you probaby wouldn't create a password by hand like this, but
+    instead get one in a JSON request.  The
+    [`FromJSON`](https://hackage.haskell.org/package/password-instances-2.0.0.1/docs/Data-Password-Instances.html#v:-36-fFromJSONPassword)
+    instance for `Password` provided by
+    [`password-instances`](https://hackage.haskell.org/package/password-instances-2.0.0.1)
+    makes this easy.
+
+[^3]: This is made easier with the
+    [`PersistField`](https://hackage.haskell.org/package/password-instances-2.0.0.1/docs/Data-Password-Instances.html#v:-36-fPersistFieldPasswordHash)
+    instance for `PasswordHash` from
+    [`password-instances`](https://hackage.haskell.org/package/password-instances-2.0.0.1).
 

--- a/2020-05-16-password-2.0.md
+++ b/2020-05-16-password-2.0.md
@@ -27,7 +27,7 @@ dealing with passwords and password hashing in any type of application.
 
 There are four main advantages of using `password`:
 
--   Cannonical
+-   Canonical
     [`Password`](https://hackage.haskell.org/package/password-2.0.1.1/docs/Data-Password.html#t:PasswordHash)
     and
     [`PasswordHash`](https://hackage.haskell.org/package/password-2.0.1.1/docs/Data-Password.html#t:PasswordHash)
@@ -54,12 +54,11 @@ There are four main advantages of using `password`:
 -   Great documentation.  Anything confusing in the Haddocks is considered a
     "high-priority" bug.
 
-## What has changed in `password-2.0`?
+## What changed in `password-2.0`?
 
-`password-2.0` is a complete rewrite of the `password` library by [Felix
-Paulusma](https://github.com/Vlix)[^1].  The architecture of the library has
-been completely redone to allow the library to support multiple hashing
-algorithms.
+`password-2.0` is a complete rewrite of the `password` library by
+[Felix Paulusma](https://github.com/Vlix)[^1].  The architecture of the library
+has been completely redone to support multiple hashing algorithms.
 
 The following algorithms are now supported:
 
@@ -67,7 +66,7 @@ The following algorithms are now supported:
 -   [Bcrypt](https://hackage.haskell.org/package/password-2.0.1.1/docs/Data-Password-Bcrypt.html)
 -   [PBKDF2](https://hackage.haskell.org/package/password-2.0.1.1/docs/Data-Password-PBKDF2.html)
 -   [Scrypt](https://hackage.haskell.org/package/password-2.0.1.1/docs/Data-Password-Scrypt.html)
-    (this was the only algorithm supported in the original `password` library)
+    (this was the only algorithm supported in the original `password-1.0` library)
 
 `password-2.0` also adds a bunch of much-needed documentation, as well as many
 tests.
@@ -88,10 +87,10 @@ We enable a couple extensions to make the following code a little easier:
 The first step in using `password` is to pick which hashing algorithm you want to use.
 If you don't know which to pick, we recommend
 [Bcrypt](https://hackage.haskell.org/package/password-2.0.1.1/docs/Data-Password-Bcrypt.html).
-The tradeoffs of the different algorithms are discussed in more detail
+The trade-offs of the different algorithms are discussed in more detail
 [in the Haddocks](https://hackage.haskell.org/package/password-2.0.1.1/docs/Data-Password.html).
 
-Once, you've picked the hashing algorithm, you can import its module.  We use
+Once you've picked the hashing algorithm, you can import its module.  We use
 [`Data.Password.Bcrypt`](https://hackage.haskell.org/package/password-2.0.1.1/docs/Data-Password-Bcrypt.html)
 as an example:
 
@@ -155,8 +154,8 @@ anyone interested!
     dependency on `cryptonite`.
 
     Ideally, we would have a `password-types` package that just exports
-    everything from the current `Data.Password` module, which doesn't require a
-    dependency on `cryptonite`.
+    everything from the current `Data.Password` module (which doesn't require a
+    dependency on `cryptonite`).
 
     https://github.com/cdepillabout/password/issues/20
 
@@ -165,8 +164,9 @@ anyone interested!
 -   Split the `password-instances` package into separate packages.
 
     Currently, `password-instances` has instances for `Password` and
-    `PasswordHash` for type classes from `aeson` and `persistent`.  However,
-    ideally there would be a more fine-grained way to pick only the instances
+    `PasswordHash` for type classes from `aeson` and `persistent`.
+
+    Ideally, there would be a more fine-grained way to pick only the instances
     you want.
 
     For instance, if you're not using `persistent` to access a database, you
@@ -204,7 +204,7 @@ anyone interested!
     [email me directly](https://functor.tokyo/about) if you don't feel
     comfortable creating a public issue on GitHub.
 
-Please feel free to send PRs or create issues for any of the above enhancements.
+Please feel free to send pull requests or create issues for any of the above enhancements.
 
 ## Conclusion and Thanks
 
@@ -223,14 +223,14 @@ There were a few other people who contributed as well:
 -   [Tristan de Cacqueray](https://github.com/TristanCacqueray)
     [fixed up](https://github.com/cdepillabout/password/pull/19) some of our Haddocks.
 
-Thanks to everyone, and I hope we get some more contributions in the future!
+Thanks to everyone, and I hope we get more contributions in the future!
 
 ## Footnotes
 
 [^1]: The bulk of this work happened in
     [this PR](https://github.com/cdepillabout/password/pull/8).
 
-[^2]: In reality, you probaby wouldn't create a password by hand like this, but
+[^2]: In reality, you probably wouldn't create a password by hand like this, but
     instead get one in a JSON request.  The
     [`FromJSON`](https://hackage.haskell.org/package/password-instances-2.0.0.1/docs/Data-Password-Instances.html#v:-36-fFromJSONPassword)
     instance for `Password` provided by
@@ -241,4 +241,3 @@ Thanks to everyone, and I hope we get some more contributions in the future!
     [`PersistField`](https://hackage.haskell.org/package/password-instances-2.0.0.1/docs/Data-Password-Instances.html#v:-36-fPersistFieldPasswordHash)
     instance for `PasswordHash` from
     [`password-instances`](https://hackage.haskell.org/package/password-instances-2.0.0.1).
-

--- a/2020-05-16-password-2.0.md
+++ b/2020-05-16-password-2.0.md
@@ -115,7 +115,7 @@ leaking into your web application logs.
 
 Now that you have a password, we can hash it with the
 [`hashPassword`](https://hackage.haskell.org/package/password-2.0.1.1/docs/Data-Password-Bcrypt.html#v:hashPassword)
-function.  This produces a
+function[^4].  This produces a
 [`PasswordHash`](https://hackage.haskell.org/package/password-2.0.1.1/docs/Data-Password-Bcrypt.html#t:PasswordHash):
 
 ```haskell
@@ -245,3 +245,12 @@ Thanks to everyone, and I hope we get more contributions in the future!
     [`PersistField`](https://hackage.haskell.org/package/password-instances-2.0.0.1/docs/Data-Password-Instances.html#v:-36-fPersistFieldPasswordHash)
     instance for `PasswordHash` from
     [`password-instances`](https://hackage.haskell.org/package/password-instances-2.0.0.1).
+
+[^4]: Note that
+    [`PasswordHash`](https://hackage.haskell.org/package/password-2.0.1.1/docs/Data-Password.html#t:PasswordHash),
+    [`hashPassword`](https://hackage.haskell.org/package/password-2.0.1.1/docs/Data-Password-Bcrypt.html#v:hashPassword),
+    and
+    [`checkPassword](https://hackage.haskell.org/package/password-2.0.1.1/docs/Data-Password-Bcrypt.html#v:checkPassword)
+    all have a phantom parameter.  This is used to store the algorithm that was
+    used to hash the password.  You are not able to call `checkPassword` on a
+    hash produced from a different algorithm's `hashPassword`.

--- a/2020-05-16-password-2.0.md
+++ b/2020-05-16-password-2.0.md
@@ -166,7 +166,8 @@ anyone interested!
     package into separate packages.
 
     Currently, `password-instances` has instances for `Password` and
-    `PasswordHash` for type classes from `aeson` and `persistent`.
+    `PasswordHash` for type classes from `aeson`, `http-api-data`, and
+    `persistent`.
 
     Ideally, there would be a more fine-grained way to pick only the instances
     you want.

--- a/2020-05-16-password-2.0.md
+++ b/2020-05-16-password-2.0.md
@@ -1,10 +1,71 @@
-title = Announcing password-2.0.0.0
+title = Announcing password-2.0
 summary = A library for working with passwords in Haskell
 tags = haskell
 draft = true
 
 ------------------------------------------------------
 
+I recently helped with the release of the
+[password-2.0](https://hackage.haskell.org/package/password-2.0.1.1) library.
+
+This 2.0 release corresponds to a big rewrite of the `password` library,
+spearheaded entirely by [Felix Paulusma](https://github.com/Vlix).
+
+The biggest improvement in 2.0 is the addition of a few new options for hashing
+algorithms, including
+[Argon2](https://hackage.haskell.org/package/password-2.0.1.1/docs/Data-Password-Argon2.html),
+[Bcrypt](https://hackage.haskell.org/package/password-2.0.1.1/docs/Data-Password-Bcrypt.html),
+and
+[PBKDF2](https://hackage.haskell.org/package/password-2.0.1.1/docs/Data-Password-PBKDF2.html).
+
+## What is the `password` library?
+
+The [`password`](https://hackage.haskell.org/package/password-2.0.1.1) library
+was originally intended to be used by people implementing username/password
+authentication in web applications, but it is now easily usable by anyone
+dealing with passwords and password hashing in any type of application.
+
+There are four main advantages of using `password`:
+
+-   Cannonical
+    [`Password`](https://hackage.haskell.org/package/password-2.0.1.1/docs/Data-Password.html#t:PasswordHash)
+    and
+    [`PasswordHash`](https://hackage.haskell.org/package/password-2.0.1.1/docs/Data-Password.html#t:PasswordHash)
+    types that can be shared throughout your code. These are meant to be simple
+    types with reasonable typeclass instances.  You should be able to take
+    `password` as a dependency and rely on these types from other libraries.
+
+-   Easy-to-use functions for hashing a `Password`, and checking a
+    `PasswordHash` against a `Password`.
+
+-   An optional
+    [password-instances](https://hackage.haskell.org/package/password-instances-2.0.0.1)
+    package that provides additional typeclass instances for `Password` and
+    `PasswordHash`, like
+    [`FromJSON`](https://hackage.haskell.org/package/password-instances-2.0.0.1/docs/Data-Password-Instances.html#v:-36-fFromJSONPassword)
+    (from [aeson](https://hackage.haskell.org/package/aeson)),
+    [FromHttpApiData](https://hackage.haskell.org/package/password-instances-2.0.0.1/docs/Data-Password-Instances.html#v:-36-fFromHttpApiDataPassword)
+    (from [http-api-data](https://hackage.haskell.org/package/http-api-data)),
+    and
+    [PersistField](https://hackage.haskell.org/package/password-instances-2.0.0.1/docs/Data-Password-Instances.html#v:-36-fFromHttpApiDataPassword)
+    (from [persistent](https://hackage.haskell.org/package/persistent)).  These
+    instances are frequently used when doing actual web development.
+
+-   Great documentation.  Anything that is confusing in the Haddocks is
+    considered a "high-priority" bug.
+
+## What was changed in `password-2.0`?
+
+
+## Future Work
+
+-   security audit
+-   splitting off the Data.Password module into a separate package called `password-types`.
+-   adding more password hashing algorithms
+-   splitting the `password-instances` package into separate packages like `password-instances-aeson`.
+-   adding more helpful `password-instances` instances.
 
 ## Conclusion
+
+testtest
 

--- a/2020-05-16-password-2.0.md
+++ b/2020-05-16-password-2.0.md
@@ -64,8 +64,10 @@ There are four main advantages of using `password`:
 -   adding more password hashing algorithms
 -   splitting the `password-instances` package into separate packages like `password-instances-aeson`.
 -   adding more helpful `password-instances` instances.
+-   functionality for validating passwords
 
-## Conclusion
+## Conclusion and Thanks
 
-testtest
+- felix
+- maralorn and scrypt maintainer https://github.com/cdepillabout/password/issues/15
 

--- a/2020-05-16-password-2.0.md
+++ b/2020-05-16-password-2.0.md
@@ -159,8 +159,6 @@ anyone interested!
 
     https://github.com/cdepillabout/password/issues/20
 
--   Add more password hashing algorithms.
-
 -   Split the
     [`password-instances`](https://hackage.haskell.org/package/password-instances-2.0.0.1)
     package into separate packages.
@@ -184,6 +182,22 @@ anyone interested!
     but it is missing many more.
 
     If you use `password`, please consider contributing missing instances!
+
+-   Support different hash formats.
+
+    `password` has its own way of encoding hashes.  In the above example,
+    you can see that the Bcrypt algorithm outputs hashes that look like this:
+    `$2b$10$IbnlktUyGjeunSlE4bQtfu89LY6veyDW0CGIoR5Kj8qrQa916txMS`.
+
+    This works well if you're writing your application from the beginning with
+    `password`, but if you're trying to interoperate with password hashes
+    produced by other languages and frameowrks, you'll have to do some manual
+    conversion.
+
+    It would be nice to extend the `checkPassword` and `hashPassword` functions
+    to be able to read/write password hashes in other formats.
+
+    https://github.com/cdepillabout/password/issues/11
 
 -   Add functionality for validating password complexity requirements.
 

--- a/2020-05-18-password-2.0.md
+++ b/2020-05-18-password-2.0.md
@@ -1,7 +1,7 @@
 title = Announcing password-2.0
 summary = A library for working with passwords in Haskell
 tags = haskell
-draft = true
+draft = false
 
 ------------------------------------------------------
 

--- a/2020-05-18-password-2.0.md
+++ b/2020-05-18-password-2.0.md
@@ -75,10 +75,11 @@ tests.
 
 This section will present a short tutorial for using `password`.  The following
 commands are run in a GHCi session.  You can follow along if you start GHCi
-with a command like `stack --resolver nightly-2020-05-17 ghci --package
+with a command like `stack --resolver nightly-2020-05-16 ghci --package
 password-2.0.1.1`.
 
-We enable a couple extensions to make the following code a little easier:
+Enable the `OverloadedStrings` extension to make the following code a little
+easier:
 
 ```haskell
 > :set -XOverloadedStrings
@@ -139,7 +140,7 @@ PasswordCheckSuccess
 ## Future Work
 
 There are a few issues in the `password` library that we'd like help with from
-anyone interested!
+anyone interested.
 
 -   Split off the
     [`Data.Password`](https://hackage.haskell.org/package/password-2.0.1.1/docs/Data-Password.html)
@@ -191,7 +192,7 @@ anyone interested!
 
     This works well if you're writing your application from the beginning with
     `password`, but if you're trying to interoperate with password hashes
-    produced by other languages and frameowrks, you'll have to do some manual
+    produced by other languages and frameworks, you'll have to do some manual
     conversion.
 
     It would be nice to extend the `checkPassword` and `hashPassword` functions
@@ -264,7 +265,7 @@ Thanks to everyone, and I hope we get more contributions in the future!
     [`PasswordHash`](https://hackage.haskell.org/package/password-2.0.1.1/docs/Data-Password.html#t:PasswordHash),
     [`hashPassword`](https://hackage.haskell.org/package/password-2.0.1.1/docs/Data-Password-Bcrypt.html#v:hashPassword),
     and
-    [`checkPassword](https://hackage.haskell.org/package/password-2.0.1.1/docs/Data-Password-Bcrypt.html#v:checkPassword)
+    [`checkPassword`](https://hackage.haskell.org/package/password-2.0.1.1/docs/Data-Password-Bcrypt.html#v:checkPassword)
     all have a phantom parameter.  This is used to store the algorithm that was
     used to hash the password.  You are not able to call `checkPassword` on a
     hash produced from a different algorithm's `hashPassword`.


### PR DESCRIPTION
This is a blog post announcing the new password-2.0 library.

Here is a rendered version: https://functor.tokyo/blog/draft/2020-05-16-password-2.0 (although note that the url will change when it has actually been fully published)